### PR TITLE
Update searching by adding new search behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
   <!-- NAVBAR -->
   <nav id="navbar" class="navbar navbar-expand-lg sticky-top">
     <div class="container-fluid mt-1 mb-1">
-      <a class="navbar-brand d-flex justify-content-center align-items-center" href="#"
+      <a class="navbar-brand d-flex justify-content-center align-items-center" href="index.html"
         title="Reload Website"><strong>MovieShowLand</strong> <img
           src="./src/assets/images/icons/popcorn_glass_second.svg" alt="MovieShowLand Logo" class="ms-1"></a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"


### PR DESCRIPTION
Before this, when you search… titles, the titles loads in the same page 'index.html', but if you want to go back to the main page, you are already in the main page, because the search titles override the original titles loaded at the start of the website, now, if you want to search titles, the query in the search input will be set to a new url like 'index.html?query=whatever', and will redirect to a new page, is the same page, but we have a search param to load the titles, because, we have a listener when the DOMContentLoaded, and we read the search param, in case the url have a search param, we load the titles with the function 'searchTitleByName()' and pass it that param, otherwise, only remains like the original load, and is a more conventional behavior for the user, more intuitive, because before this, you have to reload manually the website, now you only have to go back and thats it