### PR TITLE
Change title element to 'h2' instead of 'h5'

### DIFF
--- a/src/js/components/principalCard.js
+++ b/src/js/components/principalCard.js
@@ -53,8 +53,8 @@ export const createPrincipalCard = (item) => {
     const cardBody = document.createElement('div');
     cardBody.className = 'card-body d-flex flex-column';
 
-    const title = document.createElement('h5');
-    title.className = 'card-title text-center mb-4';
+    const title = document.createElement('h2');
+    title.className = 'card-title text-center mb-4 h5';
     title.textContent = item['primaryTitle'];
 
     // Helper to create <p><strong>Label:</strong> Value</p> elements


### PR DESCRIPTION
but with bootstrap you can choose a font size based on 'h' titles, and you set it by className, i set font size style like 'h5' with and real 'h2' element to have a better accesibility on pagespeed insights